### PR TITLE
feat: enable social segment for navigation header

### DIFF
--- a/packages/boilerplate/src/page-template/page-template.tsx
+++ b/packages/boilerplate/src/page-template/page-template.tsx
@@ -16,7 +16,6 @@ import {
   useEmbeds,
 } from '@wheelroom/core'
 import { BlogModel, AllBlogModel } from '@wheelroom/wheel-blog'
-import { DocsModel, AllDocsModel } from '@wheelroom/wheel-doc'
 import { Sections, SectionsProps } from './sections'
 import { sectionWheels } from './section-wheels'
 import { SeoProps } from './seo-props'
@@ -47,8 +46,6 @@ const PageTemplate = (props: any) => {
   const globals: GlobalsModel = props.data.globals
   const blog: BlogModel = props.data.blog
   const allBlog: AllBlogModel = props.data.allBlog
-  const docs: DocsModel = props.data.docs
-  const allDocs: AllDocsModel = props.data.allDocs
   const locale = props.pageContext.locale
   const namedPaths = props.pageContext.namedPaths
   const siteMetadata: CoreSiteMetadata = props.data.site.siteMetadata
@@ -62,8 +59,6 @@ const PageTemplate = (props: any) => {
     globals,
     blog,
     allBlog,
-    docs,
-    allDocs,
     page,
     siteMetadata,
 
@@ -74,14 +69,16 @@ const PageTemplate = (props: any) => {
   const pageImageSrc =
     (page.seoImage && page.seoImage.fluid && page.seoImage.fluid.src) || ''
   const blogImageSrc =
-    (blog.seoImage && blog.seoImage.fluid && blog.seoImage.fluid.src) || ''
+    (blog && blog.seoImage && blog.seoImage.fluid && blog.seoImage.fluid.src) ||
+    ''
   const siteImageSrc =
     (globals.siteImage &&
       globals.siteImage.fluid &&
       globals.siteImage.fluid.src) ||
     ''
   const blogAuthor =
-    (Array.isArray(blog.authors) &&
+    (blog &&
+      Array.isArray(blog.authors) &&
       blog.authors.length > 0 &&
       blog.authors[0].heading) ||
     ''
@@ -89,7 +86,7 @@ const PageTemplate = (props: any) => {
     authorArray: [blogAuthor, globals.siteAuthor],
     descriptionArray: [
       page.seoDescription,
-      blog.seoDescription,
+      blog && blog.seoDescription,
       globals.siteDescription,
     ],
     headingArray: [page.seoTitle, blog.seoTitle, globals.siteHeading],
@@ -124,7 +121,7 @@ const PageTemplate = (props: any) => {
 export default PageTemplate
 
 export const query = graphql`
-  query($pageId: String, $globalsId: String, $blogId: String, $docsId: String) {
+  query($pageId: String, $globalsId: String, $blogId: String) {
     site {
       siteMetadata {
         siteVersion
@@ -154,16 +151,6 @@ export const query = graphql`
       edges {
         node {
           ...Blog
-        }
-      }
-    }
-    docs: contentfulDocs(id: { eq: $docsId }) {
-      ...Docs
-    }
-    allDocs: allContentfulDocs {
-      edges {
-        node {
-          ...Docs
         }
       }
     }

--- a/packages/boilerplate/src/themes/glacier/data/navigation-data.tsx
+++ b/packages/boilerplate/src/themes/glacier/data/navigation-data.tsx
@@ -7,6 +7,7 @@ export const navigationSectionData: DeepPartial<NavigationSectionData> = {
     hideBranding: false,
     hideMenu: false,
     hideModal: false,
+    hideSocial: false,
     hideSkipToContent: false,
     hideThemeButton: false,
     /**

--- a/packages/boilerplate/src/themes/glacier/ncss-trees/navigation/navigation-section/header-ncss-tree.ts
+++ b/packages/boilerplate/src/themes/glacier/ncss-trees/navigation/navigation-section/header-ncss-tree.ts
@@ -111,6 +111,31 @@ export const navigationSectionHeaderNcssTree: DeepPartial<NavigationSectionHeade
         },
       ]),
     },
+    social: {
+      ncss: {
+        label: 'social-navigation',
+        display: ['none', 'none', 'flex'],
+      },
+      segment: deepMerge([
+        navigationSegmentNcssTree,
+        {
+          list: {
+            ncss: {
+              textAlign: 'center',
+            },
+          },
+          action: {
+            ncss: {
+              px: 2,
+              py: 3,
+              ':hover': {
+                color: 'sectionText',
+              },
+            },
+          },
+        },
+      ]),
+    },
     actions: {
       ncss: {
         label: 'actions-navigation',
@@ -248,6 +273,33 @@ export const navigationSectionHeaderNcssTree: DeepPartial<NavigationSectionHeade
                 },
                 icon: {
                   ncss: {},
+                },
+              },
+            },
+          ]),
+        },
+        social: {
+          ncss: {
+            label: 'social-navigation',
+            flexDirection: 'column',
+            w: 1,
+            p: 1,
+          },
+          segment: deepMerge([
+            navigationSegmentNcssTree,
+            {
+              list: {
+                ncss: {
+                  textAlign: 'center',
+                },
+              },
+              action: {
+                ncss: {
+                  px: 2,
+                  py: 3,
+                  ':hover': {
+                    color: 'sectionText',
+                  },
                 },
               },
             },

--- a/packages/wheel-navigation/src/models/navigation-section/header/data.ts
+++ b/packages/wheel-navigation/src/models/navigation-section/header/data.ts
@@ -3,6 +3,7 @@ export interface NavigationSectionHeaderData {
   hideBranding: boolean
   hideMenu: boolean
   hideModal: boolean
+  hideSocial: boolean
   hideSkipToContent: boolean
   hideThemeButton: boolean
   useLogoElement: JSX.Element | undefined

--- a/packages/wheel-navigation/src/models/navigation-section/header/modal.tsx
+++ b/packages/wheel-navigation/src/models/navigation-section/header/modal.tsx
@@ -28,6 +28,9 @@ export interface ModalNcssTree {
   menu: {
     segment: NavigationSegmentNcssTree
   } & NcssNode
+  social: {
+    segment: NavigationSegmentNcssTree
+  } & NcssNode
   actions: {
     segment: NavigationSegmentNcssTree
     themeButton: NcssNode
@@ -45,6 +48,7 @@ export interface ModalProps {
   hideThemeButton?: boolean
   menuSegments: NavigationSegmentModel[]
   menuVisible: boolean
+  socialSegments: NavigationSegmentModel[]
   toggleTheme: () => void
   wheel: ModalWheel
 }
@@ -129,6 +133,24 @@ export const Modal = (props: ModalProps) => {
             }}
           />
         </Flex>
+        <Flex
+          is="div"
+          wheel={{ ...props.wheel, style: props.wheel.style.social }}
+        >
+          <NavigationSegment
+            headingElementName="h3"
+            hideActionHeading={true}
+            hideActionIcon={false}
+            hideSegmentHeading={true}
+            maxSegments={1}
+            navigationSegment={props.socialSegments}
+            wheel={{
+              ...props.wheel,
+              style: props.wheel.style.social.segment,
+            }}
+          />
+        </Flex>
+
         <Flex
           is="div"
           wheel={{ ...props.wheel, style: props.wheel.style.actions }}

--- a/packages/wheel-navigation/src/models/navigation-section/header/navigation-header.tsx
+++ b/packages/wheel-navigation/src/models/navigation-section/header/navigation-header.tsx
@@ -36,6 +36,9 @@ export interface NavigationSectionHeaderNcssTree {
     menu: {
       segment: NavigationSegmentNcssTree
     } & NcssNode
+    social: {
+      segment: NavigationSegmentNcssTree
+    } & NcssNode
     actions: {
       segment: NavigationSegmentNcssTree
       themeButton: NcssNode
@@ -98,6 +101,7 @@ export const NavigationHeader = (props: NavigationHeaderProps) => {
   const actionsSegments = getNavSegments(props.navigation, 'actions')
   const brandSegments = getNavSegments(props.navigation, 'brand')
   const menuSegments = getNavSegments(props.navigation, 'menu')
+  const socialSegments = getNavSegments(props.navigation, 'social')
 
   const toggleTheme = () => {
     setActiveTheme(getNextKey(props.themes, activeThemeId))
@@ -153,12 +157,34 @@ export const NavigationHeader = (props: NavigationHeaderProps) => {
                 headingElementName="h3"
                 hideActionHeading={false}
                 hideActionIcon={false}
-                hideSegmentHeading={true}
-                maxSegments={1}
+                hideSegmentHeading={false}
+                maxSegments={10}
                 navigationSegment={menuSegments}
                 wheel={{
                   ...props.wheel,
                   style: props.wheel.style.header.menu.segment,
+                }}
+              />
+            </Flex>
+          )}
+          {!props.data.hideSocial && (
+            <Flex
+              is={'div'}
+              wheel={{
+                ...props.wheel,
+                style: props.wheel.style.header.social,
+              }}
+            >
+              <NavigationSegment
+                headingElementName="h3"
+                hideActionHeading={true}
+                hideActionIcon={false}
+                hideSegmentHeading={true}
+                maxSegments={1}
+                navigationSegment={socialSegments}
+                wheel={{
+                  ...props.wheel,
+                  style: props.wheel.style.header.social.segment,
                 }}
               />
             </Flex>
@@ -223,6 +249,7 @@ export const NavigationHeader = (props: NavigationHeaderProps) => {
                 hideThemeButton={props.data.hideThemeButton}
                 menuSegments={menuSegments}
                 menuVisible={menuVisible}
+                socialSegments={socialSegments}
                 toggleTheme={toggleTheme}
                 wheel={{
                   ...props.wheel,


### PR DESCRIPTION
**Enable social segment for navigation header**

A social segment now can be added to the header navigation.

**Dropdown menu**

Navigation now supports a dropdown header. This required two changes:

- The header menu has a limit of 10 segments instead of 1
- The header menu shows the segment heading

** Maintenance changes **

Remove all refs to docs in the boilerplate. E.g.
```js
import { DocsModel, AllDocsModel } from '@wheelroom/wheel-doc'
```